### PR TITLE
fixed order create method

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,5 +1,6 @@
 class Cart < ApplicationRecord
   has_many :line_items, dependent: :destroy
+  belongs_to :order
   # has_one :user
 
   def add_item(item)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,7 @@
 class Order < ApplicationRecord
   belongs_to :user
-  has_many :items
+  has_many :line_items
+  has_many :items, through: :line_items
   belongs_to :cart
 
   # validates :devlivery_address, presence: true

--- a/db/migrate/20200919155518_remove_item_reference_from_orders.rb
+++ b/db/migrate/20200919155518_remove_item_reference_from_orders.rb
@@ -1,0 +1,5 @@
+class RemoveItemReferenceFromOrders < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :orders, :item_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_19_100056) do
+ActiveRecord::Schema.define(version: 2020_09_19_155518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,10 +95,8 @@ ActiveRecord::Schema.define(version: 2020_09_19_100056) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
-    t.bigint "item_id", null: false
     t.bigint "cart_id"
     t.index ["cart_id"], name: "index_orders_on_cart_id"
-    t.index ["item_id"], name: "index_orders_on_item_id"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
@@ -150,7 +148,6 @@ ActiveRecord::Schema.define(version: 2020_09_19_100056) do
   add_foreign_key "line_items", "carts"
   add_foreign_key "line_items", "items"
   add_foreign_key "orders", "carts"
-  add_foreign_key "orders", "items"
   add_foreign_key "orders", "users"
   add_foreign_key "reviews", "kitchens"
   add_foreign_key "reviews", "users"


### PR DESCRIPTION
Hi guys,

I've removed item_id from order table as it was not only not necessary but it was creating a conflict when trying to create a new order. 

Opened a ticket with Sahar on Saturday and we removed the column and then tested that everything was working fine.

Have a look.